### PR TITLE
Dockerized application

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,3 +30,6 @@ USER $APP_USER
 EXPOSE 4278
 
 ENTRYPOINT [ "./gravel-gateway", "-l", "0.0.0.0:4278" ]
+
+HEALTHCHECK --interval=5m --timeout=3s \
+  CMD wget --spider localhost:4278/metrics

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,5 +31,5 @@ EXPOSE 4278
 
 ENTRYPOINT [ "./gravel-gateway", "-l", "0.0.0.0:4278" ]
 
-HEALTHCHECK --interval=5m --timeout=3s \
+HEALTHCHECK --interval=30s --timeout=3s \
   CMD wget --spider localhost:4278/metrics

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM rust:alpine
+
+WORKDIR /srv
+
+COPY . .
+
+
+RUN cargo install --path .
+
+ENTRYPOINT [ "gravel-gateway" ]
+
+EXPOSE 4278

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN apk add --no-cache ca-certificates tzdata
 
 WORKDIR ${APP}
 
-COPY --from=builder ${APP}/target/x86_64-unknown-linux-musl/release .
+COPY --from=builder ${APP}/target/x86_64-unknown-linux-musl/release/gravel-gateway .
 
 RUN chown -R $APP_USER:$APP_USER ${APP}
 
@@ -30,4 +30,3 @@ USER $APP_USER
 EXPOSE 4278
 
 ENTRYPOINT [ "./gravel-gateway", "-l", "0.0.0.0:4278" ]
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,6 @@ COPY . .
 
 RUN cargo install --path .
 
-#RUN cargo build --release
-
-RUN ls -l 
 
 FROM alpine:latest as runner
 
@@ -20,8 +17,7 @@ ENV TZ=Etc/UTC \
 RUN addgroup -S $APP_USER \
     && adduser -S -g $APP_USER $APP_USER
 
-RUN apk update \
-    && apk add --no-cache ca-certificates tzdata \
+RUN apk add --no-cache ca-certificates tzdata \
     && rm -rf /var/cache/apk/*
 
 WORKDIR ${APP}

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,7 @@ ENV TZ=Etc/UTC \
 RUN addgroup -S $APP_USER \
     && adduser -S -g $APP_USER $APP_USER
 
-RUN apk add --no-cache ca-certificates tzdata \
-    && rm -rf /var/cache/apk/*
+RUN apk add --no-cache ca-certificates tzdata
 
 WORKDIR ${APP}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,38 @@
-FROM rust:alpine
+FROM ekidd/rust-musl-builder:stable as builder
 
-WORKDIR /srv
+WORKDIR /usr/src/app
 
 COPY . .
 
-
 RUN cargo install --path .
 
-ENTRYPOINT [ "gravel-gateway" ]
+#RUN cargo build --release
+
+RUN ls -l 
+
+FROM alpine:latest as runner
+
+ARG APP=/usr/src/app
+
+ENV TZ=Etc/UTC \
+    APP_USER=appuser
+
+RUN addgroup -S $APP_USER \
+    && adduser -S -g $APP_USER $APP_USER
+
+RUN apk update \
+    && apk add --no-cache ca-certificates tzdata \
+    && rm -rf /var/cache/apk/*
+
+WORKDIR ${APP}
+
+COPY --from=builder ${APP}/target/x86_64-unknown-linux-musl/release .
+
+RUN chown -R $APP_USER:$APP_USER ${APP}
+
+USER $APP_USER
 
 EXPOSE 4278
+
+ENTRYPOINT [ "./gravel-gateway", "-l", "0.0.0.0:4278" ]
+


### PR DESCRIPTION
Tested with: 
```
docker build -t prometheus-gravel-gateway .
docker run -it --rm -e RUST_BACKTRACE=1 -p 4278:4278 prometheus-gravel-gateway
```

The only problem with the dockerized app is that doesn't manager the INT signal, so pressing CTRL-C does not interrupt the daemon, the service has to be stopped with a `docker kill`

