### PR TITLE
Bump openmetrics-parser to 0.3.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["openmetrics", "prometheus", "pushgateway"]
 [dependencies]
 tokio = { version = "1", features = ["full"] }
 warp = "0.3"
-openmetrics-parser = "0.3.0"
+openmetrics-parser = "0.3.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 clap = "2.33.3"


### PR DESCRIPTION
The new version of openmetrics-parser loosens the prometheus grammar a bit
and thus should make us more compliant with actual Prometheus text exposition in the wild

In theory this solves #5 