### PR TITLE
Add rejection of metric pushes with incompatible label names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -902,9 +902,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openmetrics-parser"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4576683f2c195f905f51d85423a247ca314ab2cd13c8d2e44e0184a3ca404a24"
+checksum = "5caf1ccaaf43651cc5abda77353a173869d8d8b0238f2faacb23d6b32931e860"
 dependencies = [
  "auto_ops",
  "pest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["openmetrics", "prometheus", "pushgateway"]
 [dependencies]
 tokio = { version = "1", features = ["full"] }
 warp = "0.3"
-openmetrics-parser = "0.3.1"
+openmetrics-parser = "0.4.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 clap = "2.33.3"

--- a/src/aggregator.rs
+++ b/src/aggregator.rs
@@ -337,6 +337,10 @@ impl Aggregator {
         for (name, metrics) in metrics.families {
             match families.get_mut(&name) {
                 Some(f) => {
+                    if f.base_family.get_label_names() != metrics.get_label_names() {
+                        // The new push has different label names - abort
+                        return Err(AggregationError::Error("invalid push - new push has different label names than the existing family".to_string()))
+                    }
                     // If we have the family already, merge this new stuff into it
                     f.merge(metrics)?;
                 }

--- a/src/aggregator_test.rs
+++ b/src/aggregator_test.rs
@@ -138,3 +138,12 @@ fn test_clear_mode_aggregate() {
         exemplar: None,
     })));
 }
+
+#[tokio::test]
+async fn test_push_with_different_label_names() {
+    let mut agg = Aggregator::new();
+    assert!(agg.parse_and_merge("requests_num_total{LAMBDA_NAME=\"test_function\"} 1\n", &HashMap::new()).await.is_ok(), "failed to parse valid metric");
+    assert!(agg.parse_and_merge("requests_num_total{job=\"test\"} 1\n", &HashMap::new()).await.is_err(), "failed to reject invalid label name");
+    assert!(agg.parse_and_merge("requests_num_total{bar=\"test\"} 1\n", &HashMap::new()).await.is_err(), "failed to reject invalid label name");
+    assert!(agg.parse_and_merge("requests_num_total{LAMBDA_NAME=\"test_function\"} 1\n", &HashMap::new()).await.is_ok(), "failed to parse metric with same label name");
+}


### PR DESCRIPTION
This commit adds in a check to make sure that new pushes have the same
label names as previous pushes so that we don't end up with
inconsistencies